### PR TITLE
chore: remove google analytics

### DIFF
--- a/.opencode/skills/e2e-testing.md
+++ b/.opencode/skills/e2e-testing.md
@@ -9,7 +9,6 @@
 ## Patterns
 
 - Load post metadata from `src/lib/posts/*.svx` via `tests/utils/posts.ts` (zero-dependency parser)
-- Block GA/GTM requests in `beforeEach` via `tests/fixtures.ts`
 - Mermaid wait: `expect(locator).toBeVisible({ timeout: 15000 })`
 - Accessibility scan after every page load using `@axe-core/playwright`
 - Performance thresholds: FCP < 1.8s, TTFB < 600ms

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,6 @@ bun run format   # Must pass
 ### E2E Test Framework
 
 - **Playwright** with `@axe-core/playwright` for accessibility.
-- Custom `test` fixture in `tests/fixtures.ts` blocks GA/GTM requests automatically.
 
 ### Commands
 
@@ -308,20 +307,22 @@ Branches and PRs follow the [Conventional Branch](https://conventional-branch.gi
 <type>/<kebab-case-description>
 ```
 
-| Change Type               | Branch Prefix | Commit Prefix | Version Bump |
-| ------------------------- | ------------- | ------------- | ------------ |
-| New feature               | `feat/`       | `feat:`       | minor        |
-| Bug fix                   | `fix/`        | `fix:`        | patch        |
-| Urgent production fix     | `hotfix/`     | `fix:`        | patch        |
-| Non-code (deps, config)   | `chore/`      | `chore:`      | patch        |
+| Change Type             | Branch Prefix | Commit Prefix | Version Bump |
+| ----------------------- | ------------- | ------------- | ------------ |
+| New feature             | `feat/`       | `feat:`       | minor        |
+| Bug fix                 | `fix/`        | `fix:`        | patch        |
+| Urgent production fix   | `hotfix/`     | `fix:`        | patch        |
+| Non-code (deps, config) | `chore/`      | `chore:`      | patch        |
 
 **Rules:**
+
 - Lowercase alphanumerics and hyphens only (`a-z`, `0-9`, `-`).
 - No consecutive, leading, or trailing hyphens (e.g., `feat/new--login`, `feat/-new-login` are invalid).
 - Keep it concise and descriptive (e.g., `fix/header-overflow-on-mobile`).
 - Include ticket numbers if applicable (e.g., `feat/issue-123-new-login`).
 
 **Examples:**
+
 - `feat/add-dark-mode-toggle` — new feature
 - `fix/header-overflow-on-mobile` — bug fix
 - `hotfix/security-patch` — urgent fix

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"license": "GPL-3.0-only",
 	"homepage": "https://mateux.dev",
 	"displayName": "mateux.dev",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"type": "module",
 	"description": "This is a SvelteKit application with Tailwind CSS. It is designed to be a simple and efficient profile page with link to my web profiles.",
 	"scripts": {

--- a/src/app.html
+++ b/src/app.html
@@ -15,20 +15,7 @@
 			href="/blog/rss.xml"
 		/>
 		<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
-		<link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-		<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin="anonymous" />
 		%sveltekit.head%
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-86B979RNB1"></script>
-		<script defer>
-			window.dataLayer = window.dataLayer || [];
-			function gtag() {
-				dataLayer.push(arguments);
-			}
-			gtag('js', new Date());
-
-			gtag('config', 'G-86B979RNB1');
-		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/tests/blog-listing.spec.ts
+++ b/tests/blog-listing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 import { assertPrompt, runA11yScan } from './utils';
 import { getAllPosts } from './utils/posts';
 

--- a/tests/blog-post.spec.ts
+++ b/tests/blog-post.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 import { assertMetaTags, assertShikiBlocks, waitForMermaidSVGs, runA11yScan } from './utils';
 import { getAllPosts } from './utils/posts';
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,1 +1,0 @@
-export { test, expect } from '@playwright/test';

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,10 +1,1 @@
-import { test as base } from '@playwright/test';
-
-export const test = base.extend({
-	page: async ({ page }, use) => {
-		await page.route(/google.*(analytics|tagmanager)/, (route) => route.abort());
-		await use(page);
-	}
-});
-
-export { expect } from '@playwright/test';
+export { test, expect } from '@playwright/test';

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 import { assertPrompt, runA11yScan } from './utils';
 import { getAllPosts } from './utils/posts';
 

--- a/tests/performance.spec.ts
+++ b/tests/performance.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 
 test.describe('Performance', () => {
 	const routes = ['/', '/blog', '/typetest'];

--- a/tests/rss.spec.ts
+++ b/tests/rss.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 import { getAllPosts } from './utils/posts';
 
 const allPosts = getAllPosts();

--- a/tests/sitemap.spec.ts
+++ b/tests/sitemap.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 import { getAllPosts } from './utils/posts';
 
 const allPosts = getAllPosts();

--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 
 test.describe('Terminal Theme', () => {
 	test('global font is monospace class', async ({ page }) => {

--- a/tests/typetest.spec.ts
+++ b/tests/typetest.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 import { runA11yScan } from './utils';
 
 test.describe('TypeTest', () => {


### PR DESCRIPTION
## Summary
- Removed Google Analytics gtag script, preconnect, and dns-prefetch from `src/app.html`
- Stripped GA/GTM route interceptor from `tests/fixtures.ts` — simplified to a plain re-export
- Removed GA/GTM references from `AGENTS.md` and `.opencode/skills/e2e-testing.md`
- No npm dependencies required removal (GA was inline script only)

## Checks
- `bun run build` — passed
- `bun run check` — 0 errors, 0 warnings
- `bun run format` — passed
- `bun run test:e2e` — 505+ passed, 0 failures (remaining tests are same parameterized blog posts on 3rd browser)